### PR TITLE
Update to GTK4 and add language selection

### DIFF
--- a/io.github.thiefmd.themegenerator.json
+++ b/io.github.thiefmd.themegenerator.json
@@ -1,7 +1,7 @@
 {
     "app-id":"io.github.thiefmd.themegenerator",
     "runtime":"org.gnome.Platform",
-    "runtime-version":"41",
+    "runtime-version":"42",
     "sdk":"org.gnome.Sdk",
     "command":"io.github.thiefmd.themegenerator",
     "finish-args":[
@@ -32,8 +32,8 @@
             "buildsystem": "meson",
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.1.tar.xz",
-                "sha256": "d163d71b5fcafbc5b1eec6dd841edbdbcddd3a7511cd5fdcffd86b8bbfe69ac1"
+                "url": "https://download.gnome.org/sources/gtksourceview/5.4/gtksourceview-5.4.2.tar.xz",
+                "sha256": "ad140e07eb841910de483c092bd4885abd29baadd6e95fa22d93ed2df0b79de7"
             }]
         },
         {
@@ -43,10 +43,9 @@
             {
             "type": "git",
             "url": "https://github.com/ThiefMD/theme-generator.git",
-            "tag": "v0.0.6-flathub",
-            "commit": "38bc324a1a140a805a33a8c44641274cce72dfb4"
-            }
-        ]
+            "tag": "v0.1.0",
+            "commit": "d9acafd84fd92e590d666d8e7cfba8d8b83f7a59"
+            }]
         }
     ]
 }


### PR DESCRIPTION
Add support for non-markdown languages in preview. Update to GTK4, GtkSourceView5, and runtime 42.

![](https://raw.githubusercontent.com/ThiefMD/theme-generator/master/theme-generator-vala.png)