### PR TITLE
Update themegenerator runtime to 46

### DIFF
--- a/io.github.thiefmd.themegenerator.json
+++ b/io.github.thiefmd.themegenerator.json
@@ -1,7 +1,7 @@
 {
     "app-id":"io.github.thiefmd.themegenerator",
     "runtime":"org.gnome.Platform",
-    "runtime-version":"44",
+    "runtime-version":"46",
     "sdk":"org.gnome.Sdk",
     "command":"io.github.thiefmd.themegenerator",
     "finish-args":[


### PR DESCRIPTION
- Update themegenerator runtime to 46 since runtime version 44 has reached end-of-life.